### PR TITLE
Db update

### DIFF
--- a/SmartSaver/DataBase/DatabaseUpdater.cs
+++ b/SmartSaver/DataBase/DatabaseUpdater.cs
@@ -67,7 +67,26 @@ namespace ePiggy.DataBase
 				ExceptionHandler.Log(ex.ToString());
             }
         }
+        public static void RemoveIncomes(List<DataEntry> entries)
+        {
+            var db = new DatabaseContext();
+            List<Incomes> list = new List<Incomes>();
+            foreach (var z in entries)
+            {
+                var index = db.Incomes.FirstOrDefault(x => x.Id == z.Id);
+                list.Add(index);
+            }
 
+            try
+            {
+                db.Incomes.RemoveRange(list ?? throw new InvalidOperationException());
+                db.SaveChanges();
+            }
+            catch (InvalidOperationException ex)
+            {
+                ExceptionHandler.Log(ex.ToString());
+            }
+        }
         public static void RemoveIncome(DataEntry dataEntry)
         {
             var db = new DatabaseContext();

--- a/SmartSaver/DataBase/DatabaseUpdater.cs
+++ b/SmartSaver/DataBase/DatabaseUpdater.cs
@@ -71,12 +71,12 @@ namespace ePiggy.DataBase
         {
             var db = new DatabaseContext();
             List<Incomes> list = new List<Incomes>();
+
             foreach (var z in entries)
             {
                 var index = db.Incomes.FirstOrDefault(x => x.Id == z.Id);
                 list.Add(index);
             }
-
             try
             {
                 db.Incomes.RemoveRange(list ?? throw new InvalidOperationException());

--- a/SmartSaver/DataBase/DatabaseUpdater.cs
+++ b/SmartSaver/DataBase/DatabaseUpdater.cs
@@ -7,7 +7,7 @@ using ePiggy.Utilities;
 
 namespace ePiggy.DataBase
 {
-    public class DatabaseUpdater
+    public static class DatabaseUpdater
     {
         public static int AddGoal(int userid, string title, decimal value)
         {
@@ -68,7 +68,7 @@ namespace ePiggy.DataBase
             }
         }
 
-        public static void RemoveIncomes(List<DataEntry> entries)
+        public static void RemoveIncomes(IEnumerable<DataEntry> entries)
         {
             var db = new DatabaseContext();
             var list = new List<Incomes>();
@@ -78,15 +78,8 @@ namespace ePiggy.DataBase
                 var index = db.Incomes.FirstOrDefault(x => x.Id == z.Id);
                 list.Add(index);
             }
-            try
-            {
-                db.Incomes.RemoveRange(list ?? throw new InvalidOperationException());
-                db.SaveChanges();
-            }
-            catch (InvalidOperationException ex)
-            {
-                ExceptionHandler.Log(ex.ToString());
-            }
+            db.Incomes.RemoveRange(list ?? throw new InvalidOperationException());
+            db.SaveChanges();
         }
 
         public static void RemoveIncome(DataEntry dataEntry)
@@ -104,7 +97,7 @@ namespace ePiggy.DataBase
             }
         }
 
-        public static void RemoveExpenses(List<DataEntry> entries)
+        public static void RemoveExpenses(IEnumerable<DataEntry> entries)
         {
             var db = new DatabaseContext();
             var list = new List<Expenses>();
@@ -114,15 +107,8 @@ namespace ePiggy.DataBase
                 var index = db.Expenses.FirstOrDefault(x => x.Id == z.Id);
                 list.Add(index);
             }
-            try
-            {
-                db.Expenses.RemoveRange(list ?? throw new InvalidOperationException());
-                db.SaveChanges();
-            }
-            catch (InvalidOperationException ex)
-            {
-                ExceptionHandler.Log(ex.ToString());
-            }
+            db.Expenses.RemoveRange(list);
+            db.SaveChanges();
         }
 
         public static void RemoveExpense(DataEntry dataEntry)

--- a/SmartSaver/DataBase/DatabaseUpdater.cs
+++ b/SmartSaver/DataBase/DatabaseUpdater.cs
@@ -27,6 +27,7 @@ namespace ePiggy.DataBase
             db.SaveChanges();
             return income.Id;
         }
+
         public static int AddExpense(int userid, decimal value, string title, DateTime date, bool isMonthly,
             int importance)
         {
@@ -36,7 +37,6 @@ namespace ePiggy.DataBase
             db.SaveChanges();
             return expense.Id;
         }
-
 
         public static void RemoveGoal(int id)
         {
@@ -67,6 +67,7 @@ namespace ePiggy.DataBase
 				ExceptionHandler.Log(ex.ToString());
             }
         }
+
         public static void RemoveIncomes(List<DataEntry> entries)
         {
             var db = new DatabaseContext();
@@ -87,6 +88,7 @@ namespace ePiggy.DataBase
                 ExceptionHandler.Log(ex.ToString());
             }
         }
+
         public static void RemoveIncome(DataEntry dataEntry)
         {
             var db = new DatabaseContext();
@@ -101,6 +103,7 @@ namespace ePiggy.DataBase
 				ExceptionHandler.Log(ex.ToString());
             }
         }
+
         public static void RemoveExpenses(List<DataEntry> entries)
         {
             var db = new DatabaseContext();
@@ -121,6 +124,7 @@ namespace ePiggy.DataBase
                 ExceptionHandler.Log(ex.ToString());
             }
         }
+
         public static void RemoveExpense(DataEntry dataEntry)
         {
             var db = new DatabaseContext();
@@ -136,7 +140,6 @@ namespace ePiggy.DataBase
             }
         }
 
-        
         public static void RemoveExpense(int id)
         {
             var db = new DatabaseContext();
@@ -166,7 +169,6 @@ namespace ePiggy.DataBase
             return true;
         }
 
-        
         /*public static bool EditGoalPlaceInQueue(int id, int placeInQueue)
         {
             var db = new DatabaseContext();
@@ -179,19 +181,20 @@ namespace ePiggy.DataBase
             }
             return false;
         }*/
-         public static bool EditIncomeItem(int id, decimal value)
-         {
 
-             var db = new DatabaseContext();
-             var temp = db.Incomes.FirstOrDefault(x => x.Id == id);
-             if (temp == null)
-             {
-                 return false;
-             }
-             temp.Amount = value;
-             db.SaveChanges();
-             return true;
-         }
+        public static bool EditIncomeItem(int id, decimal value)
+        {
+
+            var db = new DatabaseContext();
+            var temp = db.Incomes.FirstOrDefault(x => x.Id == id);
+            if (temp == null)
+            {
+                return false;
+            }
+            temp.Amount = value;
+            db.SaveChanges();
+            return true;
+        }
         
         public static bool EditIncomeItem(int id, string value)
 		{
@@ -232,18 +235,18 @@ namespace ePiggy.DataBase
             return true;
         }
         
-       public static bool EditIncomeItem(int id, int importance)
-       {
-           var db = new DatabaseContext();
-           var temp = db.Incomes.FirstOrDefault(x => x.Id == id);
-           if (temp == null)
-           {
-               return false;
-           }
-           temp.Importance = importance;
-           db.SaveChanges();
-           return true;
-       }
+        public static bool EditIncomeItem(int id, int importance)
+        {
+            var db = new DatabaseContext();
+            var temp = db.Incomes.FirstOrDefault(x => x.Id == id);
+            if (temp == null)
+            {
+                return false;
+            }
+            temp.Importance = importance;
+            db.SaveChanges();
+            return true;
+        }
         
         public static bool EditIncomeItem(int id, string value, decimal amount, DateTime date, bool isMonthly, int importance)
 		{
@@ -301,7 +304,6 @@ namespace ePiggy.DataBase
             db.SaveChanges();
             return true;
         }
-        
         
         public static bool EditExpensesItem(int id, bool isMonthly)
 		{

--- a/SmartSaver/DataBase/DatabaseUpdater.cs
+++ b/SmartSaver/DataBase/DatabaseUpdater.cs
@@ -71,7 +71,7 @@ namespace ePiggy.DataBase
         public static void RemoveIncomes(List<DataEntry> entries)
         {
             var db = new DatabaseContext();
-            List<Incomes> list = new List<Incomes>();
+            var list = new List<Incomes>();
 
             foreach (var z in entries)
             {
@@ -107,7 +107,7 @@ namespace ePiggy.DataBase
         public static void RemoveExpenses(List<DataEntry> entries)
         {
             var db = new DatabaseContext();
-            List<Expenses> list = new List<Expenses>();
+            var list = new List<Expenses>();
 
             foreach (var z in entries)
             {
@@ -184,7 +184,6 @@ namespace ePiggy.DataBase
 
         public static bool EditIncomeItem(int id, decimal value)
         {
-
             var db = new DatabaseContext();
             var temp = db.Incomes.FirstOrDefault(x => x.Id == id);
             if (temp == null)

--- a/SmartSaver/DataBase/DatabaseUpdater.cs
+++ b/SmartSaver/DataBase/DatabaseUpdater.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using ePiggy.DataBase.Models;
 using ePiggy.DataManagement;
@@ -66,8 +67,7 @@ namespace ePiggy.DataBase
 				ExceptionHandler.Log(ex.ToString());
             }
         }
-        
-        
+
         public static void RemoveIncome(DataEntry dataEntry)
         {
             var db = new DatabaseContext();

--- a/SmartSaver/DataBase/DatabaseUpdater.cs
+++ b/SmartSaver/DataBase/DatabaseUpdater.cs
@@ -101,8 +101,26 @@ namespace ePiggy.DataBase
 				ExceptionHandler.Log(ex.ToString());
             }
         }
+        public static void RemoveExpenses(List<DataEntry> entries)
+        {
+            var db = new DatabaseContext();
+            List<Expenses> list = new List<Expenses>();
 
-        
+            foreach (var z in entries)
+            {
+                var index = db.Expenses.FirstOrDefault(x => x.Id == z.Id);
+                list.Add(index);
+            }
+            try
+            {
+                db.Expenses.RemoveRange(list ?? throw new InvalidOperationException());
+                db.SaveChanges();
+            }
+            catch (InvalidOperationException ex)
+            {
+                ExceptionHandler.Log(ex.ToString());
+            }
+        }
         public static void RemoveExpense(DataEntry dataEntry)
         {
             var db = new DatabaseContext();

--- a/SmartSaver/DataManagement/Data.cs
+++ b/SmartSaver/DataManagement/Data.cs
@@ -112,6 +112,7 @@ namespace ePiggy.DataManagement
 
 		public void RemoveIncomes(List<DataEntry> entries)
         {
+            DatabaseUpdater.RemoveIncomes(entries);
             Income.RemoveAll(l => entries.Contains(l));
         }
 

--- a/SmartSaver/DataManagement/Data.cs
+++ b/SmartSaver/DataManagement/Data.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using ePiggy.DataBase;
 using ePiggy.Utilities;
@@ -78,6 +79,7 @@ namespace ePiggy.DataManagement
 
         public void RemoveIncome(int id)
         {
+            Debug.WriteLine("RemoveIncome(int id)");
             var income = Income.FirstOrDefault(x => x.Id == id);
             if (income == null) return;
             Income.Remove(income);
@@ -86,6 +88,7 @@ namespace ePiggy.DataManagement
 
         public void RemoveIncome(DataEntry dataEntry)
         {
+            Debug.WriteLine("RemoveIncome(DataEntry dataEntry)");
             Income.Remove(dataEntry);
             DatabaseUpdater.RemoveIncome(dataEntry);
         }
@@ -109,15 +112,12 @@ namespace ePiggy.DataManagement
 
 		public void RemoveIncomes(List<DataEntry> entries)
         {
-            foreach (var entry in entries)
-            {
-                RemoveIncome(entry.Id);
-            }
+            Income.RemoveAll(l => entries.Contains(l));
         }
 
         public void RemoveIncomes(List<int> idList)
 		{
-			foreach (var id in idList)
+            foreach (var id in idList)
             {
                 RemoveIncome(id);
             }

--- a/SmartSaver/DataManagement/Data.cs
+++ b/SmartSaver/DataManagement/Data.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using ePiggy.DataBase;
 using ePiggy.Utilities;
@@ -77,7 +76,6 @@ namespace ePiggy.DataManagement
 
         public void RemoveIncome(int id)
         {
-            Debug.WriteLine("RemoveIncome(int id)");
             var income = Income.FirstOrDefault(x => x.Id == id);
             if (income == null) return;
             Income.Remove(income);
@@ -86,7 +84,6 @@ namespace ePiggy.DataManagement
 
         public void RemoveIncome(DataEntry dataEntry)
         {
-            Debug.WriteLine("RemoveIncome(DataEntry dataEntry)");
             Income.Remove(dataEntry);
             DatabaseUpdater.RemoveIncome(dataEntry);
         }

--- a/SmartSaver/DataManagement/Data.cs
+++ b/SmartSaver/DataManagement/Data.cs
@@ -55,14 +55,13 @@ namespace ePiggy.DataManagement
         }
 
 
-		/*EXPENSES*/
+        /*EXPENSES*/
         public void AddExpense(int userid, decimal value, string title, DateTime date, bool isMonthly, int importance)
         {
             var id = DatabaseUpdater.AddExpense(userid, value, title, date, isMonthly, importance);
             var newExpense = new DataEntry(id, userid, value, title, date, isMonthly, importance);
             Expenses.Add(newExpense);
         }
-
 
 		/*Methods for removal*/
 
@@ -75,7 +74,6 @@ namespace ePiggy.DataManagement
             GoalsList.Remove(goal);
             DatabaseUpdater.RemoveGoal(id);
         }
-
 
         public void RemoveIncome(int id)
         {
@@ -93,14 +91,12 @@ namespace ePiggy.DataManagement
             DatabaseUpdater.RemoveIncome(dataEntry);
         }
         
-
         public void RemoveExpense(DataEntry dataEntry)
         {
             Expenses.Remove(dataEntry);
             DatabaseUpdater.RemoveExpense(dataEntry);
         }
         
-
         public void RemoveExpense(int id)
         {
             var dataEntry = Expenses.FirstOrDefault(x => x.Id == id);
@@ -122,7 +118,6 @@ namespace ePiggy.DataManagement
                 RemoveIncome(id);
             }
 		}
-
 
         public void RemoveExpenses(List<DataEntry> entries)
         {
@@ -175,7 +170,6 @@ namespace ePiggy.DataManagement
             return DatabaseUpdater.EditIncomeItem(id, value);
         }
 
-
         public bool EditIncomeItem(int id, string value)
         {
             var temp = Income.FirstOrDefault(x => x.Id == id);
@@ -186,8 +180,6 @@ namespace ePiggy.DataManagement
             temp.Title = value;
             return DatabaseUpdater.EditIncomeItem(id, value);
         }
-
-
 
         public bool EditIncomeItem(int id, DateTime date)
         {
@@ -200,7 +192,6 @@ namespace ePiggy.DataManagement
             return DatabaseUpdater.EditIncomeItem(id, date);
         }
 
-
         public bool EditIncomeItem(int id, bool isMonthly)
         {
             var temp = Income.FirstOrDefault(x => x.Id == id);
@@ -212,7 +203,6 @@ namespace ePiggy.DataManagement
             return DatabaseUpdater.EditIncomeItem(id, isMonthly);
         }
         
-
         public bool EditIncomeItem(int id, int importance)
         {
             var temp = Income.FirstOrDefault(x => x.Id == id);
@@ -223,8 +213,7 @@ namespace ePiggy.DataManagement
             temp.Importance = importance;
             return DatabaseUpdater.EditIncomeItem(id, importance);
         }
-       
-
+        
         public bool EditIncomeItem(int id, string value, decimal amount, DateTime date, bool isMonthly, int importance)
         {
             var temp = Income.FirstOrDefault(x => x.Id == id);
@@ -240,7 +229,6 @@ namespace ePiggy.DataManagement
             return DatabaseUpdater.EditIncomeItem(id, value, amount, date, isMonthly, importance);
         }
         
-
         public bool EditExpensesItem(int id, decimal value)
         {
             var temp = Expenses.FirstOrDefault(x => x.Id == id);
@@ -252,7 +240,6 @@ namespace ePiggy.DataManagement
             return DatabaseUpdater.EditExpensesItem(id, value);
         }
         
-
         public bool EditExpensesItem(int id, string value)
         {
             var temp = Expenses.FirstOrDefault(x => x.Id == id);
@@ -264,7 +251,6 @@ namespace ePiggy.DataManagement
             return DatabaseUpdater.EditExpensesItem(id, value);
         }
         
-
         public bool EditExpensesItem(int id, DateTime date)
         {
             var temp = Expenses.FirstOrDefault(x => x.Id == id);
@@ -276,7 +262,6 @@ namespace ePiggy.DataManagement
             return DatabaseUpdater.EditExpensesItem(id, date);
         }
         
-
         public bool EditExpensesItem(int id, bool isMonthly)
         {
             var temp = Expenses.FirstOrDefault(x => x.Id == id);
@@ -314,7 +299,6 @@ namespace ePiggy.DataManagement
             return DatabaseUpdater.EditExpensesItem(id, value, amount, date, isMonthly, importance);
         }
 
-        
         public void ReadIncomeFromDb()
         {
             using var context = new DatabaseContext();
@@ -325,6 +309,7 @@ namespace ePiggy.DataManagement
                 Income.Add(newIncome);
             }
         }
+
         public void ReadExpensesFromDb()
         {
             using var context = new DatabaseContext();
@@ -346,6 +331,7 @@ namespace ePiggy.DataManagement
                 GoalsList.Add(newGoal);
             }
         }
+
 		public bool GetDataEntryById(int id, out DataEntry dataEntry, EntryType entryType)
         {
             switch (entryType)

--- a/SmartSaver/DataManagement/Data.cs
+++ b/SmartSaver/DataManagement/Data.cs
@@ -109,7 +109,6 @@ namespace ePiggy.DataManagement
             DatabaseUpdater.RemoveExpense(id);
         }
         
-
 		public void RemoveIncomes(List<DataEntry> entries)
         {
             DatabaseUpdater.RemoveIncomes(entries);
@@ -127,10 +126,8 @@ namespace ePiggy.DataManagement
 
         public void RemoveExpenses(List<DataEntry> entries)
         {
-            foreach (var entry in entries)
-            {
-                RemoveExpense(entry.Id);
-            }
+            DatabaseUpdater.RemoveExpenses(entries);
+            Expenses.RemoveAll(l => entries.Contains(l));
         }
 
         public void RemoveExpenses(List<int> idList)


### PR DESCRIPTION
Improved speed of removing from database by using RemoveRange instead of Remove.

Performance Comparisons
Operations           | 100 Entities | 1,000 Entities | 10,000 Entities
Remove                | 15 ms          | 1,050 ms        | 105,000 ms
RemoveRange      | 1 ms            | 10 ms             | 120 ms

